### PR TITLE
Condense JSON output

### DIFF
--- a/vv8/vv8.go
+++ b/vv8/vv8.go
@@ -7,32 +7,33 @@ import (
 	"os"
 )
 
-type CallType int
+type CallType string
 
+// need to use strings since a value of 0 will be omitted by json's omitempty
 const (
-	Get      CallType = iota
-	Set      CallType = iota
-	New      CallType = iota
-	Function CallType = iota
+	Get      CallType = "g"
+	Set      CallType = "s"
+	New      CallType = "n"
+	Function CallType = "c"
 )
 
 type Call struct {
-	Id                  string
-	CallType            CallType
-	FunctionName        string   // Function, New
-	OwningObject        string   // Function, Get, Set
-	PositionalArguments []string // Function, New
-	PropertyName        string   // Get, Set
-	NewValue            string   // Set
+	Id                  string		`json:"cid,omitempty"`
+	CallType            CallType	`json:"call,omitempty"`
+	FunctionName        string		`json:"func,omitempty"`   // Function, New
+	OwningObject        string		`json:"obj,omitempty"`   // Function, Get, Set
+	PositionalArguments []string	`json:"args,omitempty"` // Function, New
+	PropertyName        string		`json:"prop,omitempty"`   // Get, Set
+	NewValue            string		`json:"val,omitempty"`   // Set
 }
 
 type ScriptID string
 
 type Script struct {
-	ScriptID ScriptID
-	Name     string
-	Source   string // Check on hashing
-	Calls    []Call
+	ScriptID ScriptID	`json:"sid,omitempty"`
+	Name     string		`json:"name,omitempty"`
+	Source   string		`json:"src,omitempty"` // Check on hashing
+	Calls    []Call		`json:"calls,omitempty"`
 }
 
 type Isolate map[ScriptID]*Script
@@ -65,6 +66,10 @@ func readFullLine(reader *bufio.Reader) (string, error) {
 	}
 
 	return line, nil
+}
+
+func trimOwningObject(owningObj string) (string) {
+	return owningObj[1: len(owningObj) - 1]
 }
 
 func ProcessLogFiles(filenames []string) (map[IsolateAddress]Isolate, error) {
@@ -117,17 +122,17 @@ func ProcessLogFiles(filenames []string) (map[IsolateAddress]Isolate, error) {
 				}
 			case 'c':
 				call := Call{
-					Id:                  splat[0],
+					// Id:                  splat[0],
 					CallType:            Function,
 					FunctionName:        splat[1],
-					OwningObject:        splat[2],
+					OwningObject:        trimOwningObject(splat[2]),
 					PositionalArguments: splat[3:],
 				}
 				isolateMap[curIsolateID][curScriptID].Calls = append(isolateMap[curIsolateID][curScriptID].Calls, call)
 
 			case 'n':
 				call := Call{
-					Id:                  splat[0],
+					// Id:                  splat[0],
 					CallType:            New,
 					FunctionName:        splat[1],
 					PositionalArguments: splat[2:],
@@ -136,18 +141,18 @@ func ProcessLogFiles(filenames []string) (map[IsolateAddress]Isolate, error) {
 
 			case 'g':
 				call := Call{
-					Id:           splat[0],
+					// Id:           splat[0],
 					CallType:     Get,
-					OwningObject: splat[1],
+					OwningObject: trimOwningObject(splat[1]),
 					PropertyName: splat[2],
 				}
 				isolateMap[curIsolateID][curScriptID].Calls = append(isolateMap[curIsolateID][curScriptID].Calls, call)
 
 			case 's':
 				call := Call{
-					Id:           splat[0],
+					// Id:           splat[0],
 					CallType:     Set,
-					OwningObject: splat[1],
+					OwningObject: trimOwningObject(splat[1]),
 					PropertyName: splat[2],
 					NewValue:     splat[3],
 				}


### PR DESCRIPTION
Use shorter JSON field names and use `omitempty` to remove empty fields.